### PR TITLE
Properly handling Type Information throughout the library

### DIFF
--- a/OneOf.Tests/BaseClassTests.cs
+++ b/OneOf.Tests/BaseClassTests.cs
@@ -9,8 +9,7 @@ namespace OneOf.Tests
 {
     public abstract class Response : OneOfBase<
         Response.MethodNotAllowed,
-        Response.InvokeSuccessResponse
-        >
+        Response.InvokeSuccessResponse>
     {
 
         public class MethodNotAllowed : Response
@@ -29,10 +28,12 @@ namespace OneOf.Tests
         public void CanMatchOnBase()
         {
             Response x = new Response.MethodNotAllowed();
-            Assert.AreEqual(true, 
+
+            var result  = 
                 x.Match((Response.MethodNotAllowed methodNotAllowed) => true)
-                .ElseThrow(v => new InvalidOperationException())
-                );
+                .ElseThrow(v => new InvalidOperationException());
+
+            Assert.AreEqual(true, result );
         }
     }
 

--- a/OneOf.Tests/EqualityTests.cs
+++ b/OneOf.Tests/EqualityTests.cs
@@ -46,13 +46,13 @@ namespace OneOf.Tests
         }
 
         [Test]
-        public void EqualsRequiresSameType()
+        public void EqualsDoesNotRequireSameType()
         {
             var v1 = (OneOf<string, bool>)"x";
             var v2 = (OneOf<string, bool, int>)"x";
 
             Assert.IsFalse(v1.Equals(null));
-            Assert.IsFalse(v1.Equals(v2));
+            Assert.IsTrue(v1.Equals(v2));
         }
 
     }

--- a/OneOf.Tests/IsTests.cs
+++ b/OneOf.Tests/IsTests.cs
@@ -12,7 +12,7 @@ namespace OneOf.Tests
         [Test]
         public void IsReturnsTrueWhenBool()
         {
-            var x = (OneOf<string, bool>)true;
+            var x = (OneOf<string, bool>) true;
             Assert.AreEqual(false, x.Is<string>());
             Assert.AreEqual(true, x.Is<bool>());
         }
@@ -20,10 +20,11 @@ namespace OneOf.Tests
         [Test]
         public void IsReturnsTrueWhenString()
         {
-            var x = (OneOf<string, bool>)"xyz";
+            var x = (OneOf<string, bool>) "xyz";
             Assert.AreEqual(true, x.Is<string>());
             Assert.AreEqual(false, x.Is<bool>());
         }
-    }
 
+
+    }
 }

--- a/OneOf.Tests/MatcherTests.cs
+++ b/OneOf.Tests/MatcherTests.cs
@@ -3,12 +3,13 @@ using System;
 
 namespace OneOf.Tests
 {
+    [TestFixture]
     public class MatcherTests
     {
         [Test]
         public void MatchBool()
         {
-            var oneOf = (OneOf<string, bool>)true;
+            var oneOf = (OneOf<string, bool>) true;
 
             var success = oneOf
                 .Match((string str) => false)
@@ -20,7 +21,7 @@ namespace OneOf.Tests
         [Test]
         public void MatchString()
         {
-            var oneOf = (OneOf<string, bool>)"xyz";
+            var oneOf = (OneOf<string, bool>) "xyz";
 
             var success = oneOf
                 .Match((string str) => str == "xyz")
@@ -32,7 +33,7 @@ namespace OneOf.Tests
         [Test]
         public void NoMatchReturnsDefault()
         {
-            var oneOf = (OneOf<string, bool>)"xyz";
+            var oneOf = (OneOf<string, bool>) "xyz";
 
             var success = oneOf
                 .Match((bool bln) => false)
@@ -44,13 +45,13 @@ namespace OneOf.Tests
         [Test]
         public void NoMatchThrowsException()
         {
-            var oneOf = (OneOf<string, bool>)"xyz";
+            var oneOf = (OneOf<string, bool>) "xyz";
 
             Assert.Throws<InvalidOperationException>(() =>
                 oneOf.Match((bool bln) => false)
-                     .ElseThrow(obj => new InvalidOperationException())
+                    .ElseThrow(obj => new InvalidOperationException())
                 );
         }
-    }
 
+    }
 }

--- a/OneOf.Tests/OneOf.Tests.csproj
+++ b/OneOf.Tests/OneOf.Tests.csproj
@@ -48,10 +48,12 @@
     <Compile Include="EqualityTests.cs" />
     <Compile Include="MatcherTests.cs" />
     <Compile Include="AsTests.cs" />
+    <Compile Include="PolymorphicTests.cs" />
     <Compile Include="SwitchTests.cs" />
     <Compile Include="IsTests.cs" />
     <Compile Include="BaseClassTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ToOneOfTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/OneOf.Tests/PolymorphicTests.cs
+++ b/OneOf.Tests/PolymorphicTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using NUnit.Framework;
+
+namespace OneOf.Tests
+{
+    public class PolymorphicTests
+    {
+        [Test]
+        public void MatcherMatchesOnlyOnceWhenParentClassAndSubClassesAreInOneof()
+        {
+            OneOf<Fake, Fake.One, Fake.Two> one = new Fake.One();
+            OneOf<Fake, Fake.One, Fake.Two> two = new Fake.Two();
+            OneOf<Fake, Fake.One, Fake.Two> three = new Fake.Three();
+
+            Func<OneOf<Fake, Fake.One, Fake.Two>, int> testerFunc = o =>
+            {
+                var i = 0;
+
+                var result = o.Match((Fake f) => i = 3).
+                    Match((Fake.One f) => i = 1).
+                    Match((Fake.Two f) => i = 2);
+
+                return result;
+            };
+
+            Assert.AreEqual(1, testerFunc(one));
+            Assert.AreEqual(2, testerFunc(two));
+            Assert.AreEqual(3, testerFunc(three));
+        }
+
+        [Test]
+        public void MatcherMatchesOnlyOnceWhenParentClassAndSubClassesAreInOneofAndCreationReferenceIsOfTypeParentButInstanceIsReallyChild()
+        {
+            OneOf<Fake, Fake.One, Fake.Two> hiddenOne = (Fake)new Fake.One();
+            
+            Func<OneOf<Fake, Fake.One, Fake.Two>, int> testerFunc = o =>
+            {
+                var i = 0;
+
+                var result = o.Match((Fake f) => i = 3).
+                    Match((Fake.One f) => i = 1).
+                    Match((Fake.Two f) => i = 2);
+
+                return result;
+            };
+
+            Assert.AreEqual(1, testerFunc(hiddenOne));
+        }
+
+
+        [Test]
+        public void IsReturnsTrueOnlyWhenTWasTheOriginalTypeOneOfWasConstructedWith()
+        {
+            OneOf<Fake, Fake.One, Fake.Two> one = new Fake.One();
+            OneOf<Fake, Fake.One, Fake.Two> two = new Fake.Two();
+            OneOf<Fake, Fake.One, Fake.Two> three = new Fake.Three();
+
+            Assert.True(one.Is<Fake.One>());
+            Assert.False(one.Is<Fake>());
+
+            Assert.True(two.Is<Fake.Two>());
+            Assert.False(two.Is<Fake>());
+
+            Assert.True(three.Is<Fake>());
+            Assert.False(three.Is<Fake.Three>());
+        }
+
+        [Test]
+        public void EqualsOperatorProperlyComparesUnderlyingTypesToOneOfs()
+        {
+            var origOne = new Fake.One();
+            var origTwo = new Fake.Two();
+            var origThree = new Fake.Three();
+            
+            OneOf<Fake, Fake.One, Fake.Two> one = origOne;
+            OneOf<Fake, Fake.One, Fake.Two> two = origTwo;
+            OneOf<Fake, Fake.One, Fake.Two> three = origThree;
+
+            Assert.IsTrue(one == origOne);
+            Assert.IsTrue(two == origTwo);
+            Assert.IsTrue(three == origThree);
+
+            Assert.IsTrue(origOne == one);
+            Assert.IsTrue(origTwo == two);
+            Assert.IsTrue(origThree == three);
+        }
+
+        [Test]
+        public void SwitchProperlyHandlesSubclassAndMatchesOnce()
+        {
+            var origOne = new Fake.One();
+            var origTwo = new Fake.Two();
+            var origThree = new Fake.Three();
+
+            OneOf<Fake, Fake.One, Fake.Two> one = origOne;
+            OneOf<Fake, Fake.One, Fake.Two> two = origTwo;
+            OneOf<Fake, Fake.One, Fake.Two> three = origThree;
+
+            Func<OneOf<Fake, Fake.One, Fake.Two>, int> testerFunc = o =>
+            {
+                var i = 0;
+
+                o
+                .Switch((Fake f) => i++)
+                .Switch((Fake.One f) => i++)
+                .Switch((Fake.Two f) => i++);
+
+                return i;
+            };
+
+            Assert.AreEqual(1, testerFunc(one));
+            Assert.AreEqual(1, testerFunc(two));
+            Assert.AreEqual(1, testerFunc(three));
+        }
+    }
+
+
+    public class Fake
+    {
+        public class One : Fake { }
+        public class Two : Fake { }
+        public class Three : Fake { }
+    }
+}

--- a/OneOf.Tests/ToOneOfTests.cs
+++ b/OneOf.Tests/ToOneOfTests.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+
+namespace OneOf.Tests
+{
+    [TestFixture]
+    public class ToOneOfTests
+    {
+        [Test]
+        public void ToOneOf_WhenCalledOnExistingOneOf_ProperlyConvertsToAnotherOneOf()
+        {
+            OneOf<int, string, double> oo = 1;
+
+            var a = oo.ToOneOf<byte, long, int>();
+
+            Assert.IsTrue(1 == a);
+            Assert.IsTrue(a == 1);
+        }
+    }
+}

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -3,28 +3,50 @@
 // ===========================================================================
 
 using System;
+using Microsoft.CSharp.RuntimeBinder;
 
 namespace OneOf
 {
     public struct OneOf<T0, T1> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1>((T0)value);
-            if (value is T1) return new OneOf<T0, T1>((T1)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1> Create(T0 value)
+        {
+             return new OneOf<T0, T1>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1> Create(T1 value)
+        {
+             return new OneOf<T0, T1>((T1)value, typeof(T1));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -32,52 +54,84 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.CreateRaw(value);
+        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1>(T1 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1>(T0 value) => new OneOf<T0, T1>(value);
-        public static implicit operator OneOf<T0, T1>(T1 value) => new OneOf<T0, T1>(value);
+        public static bool operator ==(OneOf<T0, T1> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1> v1, OneOf<T0, T1> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1> v1, OneOf<T0, T1> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1>(value, false).Switch(action);
-        public OneOfSwitcher<T0> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1>(value, false).Switch(action);
+        public OneOfMatcher<T1, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1> && Equals(value, ((OneOf<T0, T1>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public struct OneOf<T0, T1, T2> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1, T2> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1, T2>((T0)value);
-            if (value is T1) return new OneOf<T0, T1, T2>((T1)value);
-            if (value is T2) return new OneOf<T0, T1, T2>((T2)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1, T2> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1, T2> Create(T0 value)
+        {
+             return new OneOf<T0, T1, T2>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1, T2> Create(T1 value)
+        {
+             return new OneOf<T0, T1, T2>((T1)value, typeof(T1));
+        }
+        internal static OneOf<T0, T1, T2> Create(T2 value)
+        {
+             return new OneOf<T0, T1, T2>((T2)value, typeof(T2));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -85,56 +139,95 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1, T2>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2>(T2 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1, T2>(T0 value) => new OneOf<T0, T1, T2>(value);
-        public static implicit operator OneOf<T0, T1, T2>(T1 value) => new OneOf<T0, T1, T2>(value);
-        public static implicit operator OneOf<T0, T1, T2>(T2 value) => new OneOf<T0, T1, T2>(value);
+        public static bool operator ==(OneOf<T0, T1, T2> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1, T2> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1, T2> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1, T2> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1, T2> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1, T2> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOf<T0, T1, T2> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOf<T0, T1, T2> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1, T2> v1, OneOf<T0, T1, T2> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1, T2> v1, OneOf<T0, T1, T2> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1, T2> && Equals(value, ((OneOf<T0, T1, T2>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public struct OneOf<T0, T1, T2, T3> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1, T2, T3> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1, T2, T3>((T0)value);
-            if (value is T1) return new OneOf<T0, T1, T2, T3>((T1)value);
-            if (value is T2) return new OneOf<T0, T1, T2, T3>((T2)value);
-            if (value is T3) return new OneOf<T0, T1, T2, T3>((T3)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1, T2, T3> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1, T2, T3> Create(T0 value)
+        {
+             return new OneOf<T0, T1, T2, T3>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1, T2, T3> Create(T1 value)
+        {
+             return new OneOf<T0, T1, T2, T3>((T1)value, typeof(T1));
+        }
+        internal static OneOf<T0, T1, T2, T3> Create(T2 value)
+        {
+             return new OneOf<T0, T1, T2, T3>((T2)value, typeof(T2));
+        }
+        internal static OneOf<T0, T1, T2, T3> Create(T3 value)
+        {
+             return new OneOf<T0, T1, T2, T3>((T3)value, typeof(T3));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -142,60 +235,106 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1, T2, T3>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3>(T3 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1, T2, T3>(T0 value) => new OneOf<T0, T1, T2, T3>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3>(T1 value) => new OneOf<T0, T1, T2, T3>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3>(T2 value) => new OneOf<T0, T1, T2, T3>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3>(T3 value) => new OneOf<T0, T1, T2, T3>(value);
+        public static bool operator ==(OneOf<T0, T1, T2, T3> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1, T2, T3> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1, T2, T3> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1, T2, T3> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOf<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOf<T0, T1, T2, T3> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOf<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOf<T0, T1, T2, T3> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1, T2, T3> v1, OneOf<T0, T1, T2, T3> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1, T2, T3> v1, OneOf<T0, T1, T2, T3> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1, T2, T3> && Equals(value, ((OneOf<T0, T1, T2, T3>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1, T2, T3, T4> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1, T2, T3, T4>((T0)value);
-            if (value is T1) return new OneOf<T0, T1, T2, T3, T4>((T1)value);
-            if (value is T2) return new OneOf<T0, T1, T2, T3, T4>((T2)value);
-            if (value is T3) return new OneOf<T0, T1, T2, T3, T4>((T3)value);
-            if (value is T4) return new OneOf<T0, T1, T2, T3, T4>((T4)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1, T2, T3, T4> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1, T2, T3, T4> Create(T0 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4> Create(T1 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4>((T1)value, typeof(T1));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4> Create(T2 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4>((T2)value, typeof(T2));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4> Create(T3 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4>((T3)value, typeof(T3));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4> Create(T4 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4>((T4)value, typeof(T4));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -203,64 +342,117 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T4 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T0 value) => new OneOf<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T1 value) => new OneOf<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T2 value) => new OneOf<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T3 value) => new OneOf<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T4 value) => new OneOf<T0, T1, T2, T3, T4>(value);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOf<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOf<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOf<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOf<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOf<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOf<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1, T2, T3, T4> v1, OneOf<T0, T1, T2, T3, T4> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1, T2, T3, T4> v1, OneOf<T0, T1, T2, T3, T4> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1, T2, T3, T4> && Equals(value, ((OneOf<T0, T1, T2, T3, T4>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1, T2, T3, T4, T5> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1, T2, T3, T4, T5>((T0)value);
-            if (value is T1) return new OneOf<T0, T1, T2, T3, T4, T5>((T1)value);
-            if (value is T2) return new OneOf<T0, T1, T2, T3, T4, T5>((T2)value);
-            if (value is T3) return new OneOf<T0, T1, T2, T3, T4, T5>((T3)value);
-            if (value is T4) return new OneOf<T0, T1, T2, T3, T4, T5>((T4)value);
-            if (value is T5) return new OneOf<T0, T1, T2, T3, T4, T5>((T5)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1, T2, T3, T4, T5> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1, T2, T3, T4, T5> Create(T0 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5> Create(T1 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5>((T1)value, typeof(T1));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5> Create(T2 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5>((T2)value, typeof(T2));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5> Create(T3 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5>((T3)value, typeof(T3));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5> Create(T4 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5>((T4)value, typeof(T4));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5> Create(T5 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5>((T5)value, typeof(T5));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -268,68 +460,128 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T5 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T0 value) => new OneOf<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T1 value) => new OneOf<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T2 value) => new OneOf<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T3 value) => new OneOf<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T4 value) => new OneOf<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T5 value) => new OneOf<T0, T1, T2, T3, T4, T5>(value);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5> v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5> v1, OneOf<T0, T1, T2, T3, T4, T5> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1, T2, T3, T4, T5> && Equals(value, ((OneOf<T0, T1, T2, T3, T4, T5>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T0)value);
-            if (value is T1) return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T1)value);
-            if (value is T2) return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T2)value);
-            if (value is T3) return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T3)value);
-            if (value is T4) return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T4)value);
-            if (value is T5) return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T5)value);
-            if (value is T6) return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T6)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            if (value.GetType() == typeof(T6)) return Create((T6)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(T0 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(T1 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T1)value, typeof(T1));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(T2 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T2)value, typeof(T2));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(T3 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T3)value, typeof(T3));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(T4 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T4)value, typeof(T4));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(T5 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T5)value, typeof(T5));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6> Create(T6 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>((T6)value, typeof(T6));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -337,72 +589,139 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T5 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T6 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T0 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T1 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T2 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T3 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T4 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T5 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T6 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(value);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T6 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, T6 v2) => !v1.Equals(v2);
+        public static bool operator ==(T6 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T6 v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6> v1, OneOf<T0, T1, T2, T3, T4, T5, T6> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5, T6> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5, T6> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5, T6> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5, T6> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5, T6> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T6> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5, T6> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5, T6> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5, T6> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5, T6> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5, T6> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T6> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, T6, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, T6, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, T6, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T6, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, T6, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, T6, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, T6, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T6, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1, T2, T3, T4, T5, T6> && Equals(value, ((OneOf<T0, T1, T2, T3, T4, T5, T6>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T0)value);
-            if (value is T1) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T1)value);
-            if (value is T2) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T2)value);
-            if (value is T3) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T3)value);
-            if (value is T4) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T4)value);
-            if (value is T5) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T5)value);
-            if (value is T6) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T6)value);
-            if (value is T7) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T7)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            if (value.GetType() == typeof(T6)) return Create((T6)value);
+            if (value.GetType() == typeof(T7)) return Create((T7)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T0 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T1 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T1)value, typeof(T1));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T2 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T2)value, typeof(T2));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T3 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T3)value, typeof(T3));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T4 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T4)value, typeof(T4));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T5 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T5)value, typeof(T5));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T6 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T6)value, typeof(T6));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Create(T7 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>((T7)value, typeof(T7));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -410,76 +729,150 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T5 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T6 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T7 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T0 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T1 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T2 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T3 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T4 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T5 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T6 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T7 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(value);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T6 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T6 v2) => !v1.Equals(v2);
+        public static bool operator ==(T6 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T6 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T7 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, T7 v2) => !v1.Equals(v2);
+        public static bool operator ==(T7 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T7 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7> && Equals(value, ((OneOf<T0, T1, T2, T3, T4, T5, T6, T7>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOf(object value)
+        OneOf(object value, Type origType)
         {
             this.value = value;
-        }
-
-        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(object value)
-        {
-            if (value is T0) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T0)value);
-            if (value is T1) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T1)value);
-            if (value is T2) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T2)value);
-            if (value is T3) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T3)value);
-            if (value is T4) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T4)value);
-            if (value is T5) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T5)value);
-            if (value is T6) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T6)value);
-            if (value is T7) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T7)value);
-            if (value is T8) return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T8)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = origType;
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            if (value.GetType() == typeof(T6)) return Create((T6)value);
+            if (value.GetType() == typeof(T7)) return Create((T7)value);
+            if (value.GetType() == typeof(T8)) return Create((T8)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T0 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T0)value, typeof(T0));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T1 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T1)value, typeof(T1));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T2 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T2)value, typeof(T2));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T3 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T3)value, typeof(T3));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T4 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T4)value, typeof(T4));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T5 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T5)value, typeof(T5));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T6 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T6)value, typeof(T6));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T7 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T7)value, typeof(T7));
+        }
+        internal static OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T8 value)
+        {
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T8)value, typeof(T8));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -487,77 +880,127 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOf<N0, N1> ToOneOf<N0, N1>() => OneOf<N0, N1>.Create(value);
-        public OneOf<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOf<N0, N1, N2>.Create(value);
-        public OneOf<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOf<N0, N1, N2, N3>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOf<N0, N1, N2, N3, N4>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOf<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOf<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 value) => CreateRaw(value);
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 value) => CreateRaw(value);
 
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 value) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T6 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T6 v2) => !v1.Equals(v2);
+        public static bool operator ==(T6 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T6 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T7 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T7 v2) => !v1.Equals(v2);
+        public static bool operator ==(T7 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T7 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T8 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T8 v2) => !v1.Equals(v2);
+        public static bool operator ==(T8 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T8 v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7, T8> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7, T8> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7, T8> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7, T8> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7, T8> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T8> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7> Switch(Action<T8> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7, T8> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7, T8> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7, T8> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7, T8> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7, T8> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T8> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7> Switch(Action<T8> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, T8, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, T8, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, T8, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T8, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T8, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, T8, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, T8, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, T8, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T8, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T8, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> && Equals(value, ((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1>((T1)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1>((T1)value, typeof(T1));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -565,57 +1008,90 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1>(T1 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1>(T0 value) => new OneOfBase<T0, T1>(value);
-        public static implicit operator OneOfBase<T0, T1>(T1 value) => new OneOfBase<T0, T1>(value);
+        public static bool operator ==(OneOfBase<T0, T1> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1> v1, OneOfBase<T0, T1> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1> v1, OneOfBase<T0, T1> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1>(value, false).Switch(action);
-        public OneOfSwitcher<T0> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1>(value, false).Switch(action);
+        public OneOfMatcher<T1, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1> && Equals(value, ((OneOfBase<T0, T1>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1, T2> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1, T2> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1, T2>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1, T2>((T1)value);
-            if (value is T2) return new OneOfBase<T0, T1, T2>((T2)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1, T2> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1, T2> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1, T2>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1, T2> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1, T2>((T1)value, typeof(T1));
+        }
+        internal static OneOfBase<T0, T1, T2> Create(T2 value)
+        {
+             return new OneOfBase<T0, T1, T2>((T2)value, typeof(T2));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -623,61 +1099,101 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1, T2>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2>(T2 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1, T2>(T0 value) => new OneOfBase<T0, T1, T2>(value);
-        public static implicit operator OneOfBase<T0, T1, T2>(T1 value) => new OneOfBase<T0, T1, T2>(value);
-        public static implicit operator OneOfBase<T0, T1, T2>(T2 value) => new OneOfBase<T0, T1, T2>(value);
+        public static bool operator ==(OneOfBase<T0, T1, T2> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1, T2> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1, T2> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1, T2> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1, T2> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1, T2> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOfBase<T0, T1, T2> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOfBase<T0, T1, T2> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1, T2> v1, OneOfBase<T0, T1, T2> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1, T2> v1, OneOfBase<T0, T1, T2> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1, T2> && Equals(value, ((OneOfBase<T0, T1, T2>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1, T2, T3> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1, T2, T3> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1, T2, T3>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1, T2, T3>((T1)value);
-            if (value is T2) return new OneOfBase<T0, T1, T2, T3>((T2)value);
-            if (value is T3) return new OneOfBase<T0, T1, T2, T3>((T3)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1, T2, T3> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1, T2, T3> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1, T2, T3> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3>((T1)value, typeof(T1));
+        }
+        internal static OneOfBase<T0, T1, T2, T3> Create(T2 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3>((T2)value, typeof(T2));
+        }
+        internal static OneOfBase<T0, T1, T2, T3> Create(T3 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3>((T3)value, typeof(T3));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -685,65 +1201,112 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T3 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T0 value) => new OneOfBase<T0, T1, T2, T3>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T1 value) => new OneOfBase<T0, T1, T2, T3>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T2 value) => new OneOfBase<T0, T1, T2, T3>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T3 value) => new OneOfBase<T0, T1, T2, T3>(value);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1, T2, T3> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1, T2, T3> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOfBase<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOfBase<T0, T1, T2, T3> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOfBase<T0, T1, T2, T3> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOfBase<T0, T1, T2, T3> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1, T2, T3> v1, OneOfBase<T0, T1, T2, T3> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1, T2, T3> v1, OneOfBase<T0, T1, T2, T3> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1, T2, T3> && Equals(value, ((OneOfBase<T0, T1, T2, T3>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1, T2, T3, T4> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1, T2, T3, T4>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1, T2, T3, T4>((T1)value);
-            if (value is T2) return new OneOfBase<T0, T1, T2, T3, T4>((T2)value);
-            if (value is T3) return new OneOfBase<T0, T1, T2, T3, T4>((T3)value);
-            if (value is T4) return new OneOfBase<T0, T1, T2, T3, T4>((T4)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1, T2, T3, T4> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1, T2, T3, T4> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4>((T1)value, typeof(T1));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4> Create(T2 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4>((T2)value, typeof(T2));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4> Create(T3 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4>((T3)value, typeof(T3));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4> Create(T4 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4>((T4)value, typeof(T4));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -751,69 +1314,123 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T4 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T0 value) => new OneOfBase<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T1 value) => new OneOfBase<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T2 value) => new OneOfBase<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T3 value) => new OneOfBase<T0, T1, T2, T3, T4>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T4 value) => new OneOfBase<T0, T1, T2, T3, T4>(value);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOfBase<T0, T1, T2, T3, T4> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4> v1, OneOfBase<T0, T1, T2, T3, T4> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4> v1, OneOfBase<T0, T1, T2, T3, T4> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1, T2, T3, T4> && Equals(value, ((OneOfBase<T0, T1, T2, T3, T4>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1, T2, T3, T4, T5> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1, T2, T3, T4, T5>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1, T2, T3, T4, T5>((T1)value);
-            if (value is T2) return new OneOfBase<T0, T1, T2, T3, T4, T5>((T2)value);
-            if (value is T3) return new OneOfBase<T0, T1, T2, T3, T4, T5>((T3)value);
-            if (value is T4) return new OneOfBase<T0, T1, T2, T3, T4, T5>((T4)value);
-            if (value is T5) return new OneOfBase<T0, T1, T2, T3, T4, T5>((T5)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>((T1)value, typeof(T1));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5> Create(T2 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>((T2)value, typeof(T2));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5> Create(T3 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>((T3)value, typeof(T3));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5> Create(T4 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>((T4)value, typeof(T4));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5> Create(T5 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>((T5)value, typeof(T5));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -821,73 +1438,134 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T5 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T0 value) => new OneOfBase<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T1 value) => new OneOfBase<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T2 value) => new OneOfBase<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T3 value) => new OneOfBase<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T4 value) => new OneOfBase<T0, T1, T2, T3, T4, T5>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T5 value) => new OneOfBase<T0, T1, T2, T3, T4, T5>(value);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5> v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5> v1, OneOfBase<T0, T1, T2, T3, T4, T5> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1, T2, T3, T4, T5> && Equals(value, ((OneOfBase<T0, T1, T2, T3, T4, T5>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T1)value);
-            if (value is T2) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T2)value);
-            if (value is T3) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T3)value);
-            if (value is T4) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T4)value);
-            if (value is T5) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T5)value);
-            if (value is T6) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T6)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            if (value.GetType() == typeof(T6)) return Create((T6)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T1)value, typeof(T1));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(T2 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T2)value, typeof(T2));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(T3 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T3)value, typeof(T3));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(T4 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T4)value, typeof(T4));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(T5 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T5)value, typeof(T5));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6> Create(T6 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>((T6)value, typeof(T6));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -895,77 +1573,145 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T5 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T6 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T0 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T1 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T2 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T3 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T4 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T5 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T6 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(value);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T6 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, T6 v2) => !v1.Equals(v2);
+        public static bool operator ==(T6 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v2.Equals(v1);
+        public static bool operator !=(T6 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6> v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5, T6> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5, T6> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5, T6> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5, T6> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5, T6> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T6> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5, T6> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5, T6> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5, T6> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5, T6> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5, T6> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T6> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, T6, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, T6, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, T6, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T6, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, T6, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, T6, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, T6, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T6, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6> && Equals(value, ((OneOfBase<T0, T1, T2, T3, T4, T5, T6>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T1)value);
-            if (value is T2) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T2)value);
-            if (value is T3) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T3)value);
-            if (value is T4) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T4)value);
-            if (value is T5) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T5)value);
-            if (value is T6) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T6)value);
-            if (value is T7) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T7)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            if (value.GetType() == typeof(T6)) return Create((T6)value);
+            if (value.GetType() == typeof(T7)) return Create((T7)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T1)value, typeof(T1));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T2 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T2)value, typeof(T2));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T3 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T3)value, typeof(T3));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T4 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T4)value, typeof(T4));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T5 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T5)value, typeof(T5));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T6 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T6)value, typeof(T6));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Create(T7 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>((T7)value, typeof(T7));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -973,81 +1719,156 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.CreateRaw(value);
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T5 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T6 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T7 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T0 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T1 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T2 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T3 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T4 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T5 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T6 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T7 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(value);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T6 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T6 v2) => !v1.Equals(v2);
+        public static bool operator ==(T6 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T6 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T7 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, T7 v2) => !v1.Equals(v2);
+        public static bool operator ==(T7 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v2.Equals(v1);
+        public static bool operator !=(T7 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> && Equals(value, ((OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
         readonly object value;
+        readonly Type origType;
 
-        OneOfBase(object value)
+        OneOfBase(object value, Type origType)
         {
             this.value = value;
+            this.origType = origType;
         }
 
         protected OneOfBase()
         {
             this.value = this;
-        }
-
-        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(object value)
-        {
-            if (value is T0) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T0)value);
-            if (value is T1) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T1)value);
-            if (value is T2) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T2)value);
-            if (value is T3) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T3)value);
-            if (value is T4) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T4)value);
-            if (value is T5) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T5)value);
-            if (value is T6) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T6)value);
-            if (value is T7) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T7)value);
-            if (value is T8) return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T8)value);
-            throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));
+            this.origType = GetType();
         }
 
         object IOneOf.Value => value;
 
-        public bool Is<T>() => (this.value is T);
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> CreateRaw(object value)
+        {
+            if( value == null) throw new ArgumentNullException(nameof(value));
+            if (value.GetType() == typeof(T0)) return Create((T0)value);
+            if (value.GetType() == typeof(T1)) return Create((T1)value);
+            if (value.GetType() == typeof(T2)) return Create((T2)value);
+            if (value.GetType() == typeof(T3)) return Create((T3)value);
+            if (value.GetType() == typeof(T4)) return Create((T4)value);
+            if (value.GetType() == typeof(T5)) return Create((T5)value);
+            if (value.GetType() == typeof(T6)) return Create((T6)value);
+            if (value.GetType() == typeof(T7)) return Create((T7)value);
+            if (value.GetType() == typeof(T8)) return Create((T8)value);
+            try
+            {
+                return Create((dynamic)value);
+            }
+            catch(RuntimeBinderException ex)
+            {
+                throw new ArgumentException(nameof(value), ex);
+            }
+        }
+
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T0 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T0)value, typeof(T0));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T1 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T1)value, typeof(T1));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T2 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T2)value, typeof(T2));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T3 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T3)value, typeof(T3));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T4 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T4)value, typeof(T4));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T5 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T5)value, typeof(T5));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T6 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T6)value, typeof(T6));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T7 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T7)value, typeof(T7));
+        }
+        internal static OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Create(T8 value)
+        {
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>((T8)value, typeof(T8));
+        }
+
+        public bool Is<T>() => typeof(T) == origType;
+
+        public bool IsDerivedFrom<T>() => value is T;
 
         public T As<T>()
         {
@@ -1055,51 +1876,79 @@ namespace OneOf
 
             throw new InvalidOperationException();
         }
+        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.CreateRaw(value);
 
-        public OneOfBase<N0, N1> ToOneOf<N0, N1>() => OneOfBase<N0, N1>.Create(value);
-        public OneOfBase<N0, N1, N2> ToOneOf<N0, N1, N2>() => OneOfBase<N0, N1, N2>.Create(value);
-        public OneOfBase<N0, N1, N2, N3> ToOneOf<N0, N1, N2, N3>() => OneOfBase<N0, N1, N2, N3>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4> ToOneOf<N0, N1, N2, N3, N4>() => OneOfBase<N0, N1, N2, N3, N4>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5> ToOneOf<N0, N1, N2, N3, N4, N5>() => OneOfBase<N0, N1, N2, N3, N4, N5>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6> ToOneOf<N0, N1, N2, N3, N4, N5, N6>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7>.Create(value);
-        public OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8> ToOneOf<N0, N1, N2, N3, N4, N5, N6, N7, N8>() => OneOfBase<N0, N1, N2, N3, N4, N5, N6, N7, N8>.Create(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 value) => CreateRaw(value);
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 value) => CreateRaw(value);
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 value) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, IOneOf v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, IOneOf v2) => !v1.Equals(v2);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T0 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T0 v2) => !v1.Equals(v2);
+        public static bool operator ==(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T0 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T1 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T1 v2) => !v1.Equals(v2);
+        public static bool operator ==(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T1 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T2 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T2 v2) => !v1.Equals(v2);
+        public static bool operator ==(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T2 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T3 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T3 v2) => !v1.Equals(v2);
+        public static bool operator ==(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T3 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T4 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T4 v2) => !v1.Equals(v2);
+        public static bool operator ==(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T4 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T5 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T5 v2) => !v1.Equals(v2);
+        public static bool operator ==(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T5 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T6 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T6 v2) => !v1.Equals(v2);
+        public static bool operator ==(T6 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T6 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T7 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T7 v2) => !v1.Equals(v2);
+        public static bool operator ==(T7 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T7 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
+        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T8 v2) => v1.Equals(v2);
+        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, T8 v2) => !v1.Equals(v2);
+        public static bool operator ==(T8 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v2.Equals(v1);
+        public static bool operator !=(T8 v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v2.Equals(v1);
 
-        public static bool operator ==(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => v1.Equals(v2);
-        public static bool operator !=(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v1, OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> v2) => !v1.Equals(v2);
+        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7, T8> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7, T8> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7, T8> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7, T8> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7, T8> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T8> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
+        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7> Switch(Action<T8> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, origType, false).Switch(action);
 
-        public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T0> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T1> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7, T8> Switch(Action<T2> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7, T8> Switch(Action<T3> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7, T8> Switch(Action<T4> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7, T8> Switch(Action<T5> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7, T8> Switch(Action<T6> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T8> Switch(Action<T7> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
-        public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7> Switch(Action<T8> action) => new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value, false).Switch(action);
+        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, T8, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, T8, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, T8, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T8, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
+        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T8, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, origType, null).Match(func);
 
-        public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T0, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T1, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T2, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, T8, TResult> Match<TResult>(Func<T3, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, T8, TResult> Match<TResult>(Func<T4, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, T8, TResult> Match<TResult>(Func<T5, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, T8, TResult> Match<TResult>(Func<T6, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T8, TResult> Match<TResult>(Func<T7, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-        public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult> Match<TResult>(Func<T8, TResult> func)  => new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(value, null).Match(func);
-
-        public override bool Equals(object obj) => obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> && Equals(value, ((OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>)obj).value);
-        public override int GetHashCode() => (value?.GetHashCode() ?? 0);
+        public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);
+        public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);
         public override string ToString() => (value?.ToString() ?? "");
     }
 
@@ -1107,16 +1956,18 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public void Switch(Action<T0> action)
         {
-            if (this.value is T0) action((T0)value);
+            if (this.origType == typeof(T0)) action((T0)value);
         }
 
         public void Else(Action<object> action)
@@ -1134,31 +1985,33 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1176,41 +2029,43 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1, T2> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1, T2>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1, T2>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T2> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T2>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T2>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1> Switch(Action<T2> action)
         {
-            if (this.value is T2)
+            if (this.origType == typeof(T2))
             {
                 action((T2)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1228,51 +2083,53 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1, T2, T3> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1, T2, T3>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1, T2, T3>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T2, T3> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T2, T3>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T2, T3>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T3> Switch(Action<T2> action)
         {
-            if (this.value is T2)
+            if (this.origType == typeof(T2))
             {
                 action((T2)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T3>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T3>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2> Switch(Action<T3> action)
         {
-            if (this.value is T3)
+            if (this.origType == typeof(T3))
             {
                 action((T3)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1290,61 +2147,63 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1, T2, T3, T4> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1, T2, T3, T4>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1, T2, T3, T4>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T2, T3, T4> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T2, T3, T4>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T2, T3, T4>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T3, T4> Switch(Action<T2> action)
         {
-            if (this.value is T2)
+            if (this.origType == typeof(T2))
             {
                 action((T2)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T3, T4>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T3, T4>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T4> Switch(Action<T3> action)
         {
-            if (this.value is T3)
+            if (this.origType == typeof(T3))
             {
                 action((T3)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T4>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T4>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3> Switch(Action<T4> action)
         {
-            if (this.value is T4)
+            if (this.origType == typeof(T4))
             {
                 action((T4)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1362,71 +2221,73 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1, T2, T3, T4, T5> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1, T2, T3, T4, T5>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1, T2, T3, T4, T5>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T2, T3, T4, T5> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T2, T3, T4, T5>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T2, T3, T4, T5>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T3, T4, T5> Switch(Action<T2> action)
         {
-            if (this.value is T2)
+            if (this.origType == typeof(T2))
             {
                 action((T2)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T3, T4, T5>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T3, T4, T5>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T4, T5> Switch(Action<T3> action)
         {
-            if (this.value is T3)
+            if (this.origType == typeof(T3))
             {
                 action((T3)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T4, T5>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T4, T5>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T5> Switch(Action<T4> action)
         {
-            if (this.value is T4)
+            if (this.origType == typeof(T4))
             {
                 action((T4)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T5>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T5>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4> Switch(Action<T5> action)
         {
-            if (this.value is T5)
+            if (this.origType == typeof(T5))
             {
                 action((T5)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1444,81 +2305,83 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1, T2, T3, T4, T5, T6> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1, T2, T3, T4, T5, T6>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1, T2, T3, T4, T5, T6>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T2, T3, T4, T5, T6> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T2, T3, T4, T5, T6>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T2, T3, T4, T5, T6>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T3, T4, T5, T6> Switch(Action<T2> action)
         {
-            if (this.value is T2)
+            if (this.origType == typeof(T2))
             {
                 action((T2)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T3, T4, T5, T6>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T3, T4, T5, T6>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T4, T5, T6> Switch(Action<T3> action)
         {
-            if (this.value is T3)
+            if (this.origType == typeof(T3))
             {
                 action((T3)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T4, T5, T6>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T4, T5, T6>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T5, T6> Switch(Action<T4> action)
         {
-            if (this.value is T4)
+            if (this.origType == typeof(T4))
             {
                 action((T4)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T5, T6>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T5, T6>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T6> Switch(Action<T5> action)
         {
-            if (this.value is T5)
+            if (this.origType == typeof(T5))
             {
                 action((T5)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T6>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T6>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T5> Switch(Action<T6> action)
         {
-            if (this.value is T6)
+            if (this.origType == typeof(T6))
             {
                 action((T6)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1536,91 +2399,93 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7> Switch(Action<T2> action)
         {
-            if (this.value is T2)
+            if (this.origType == typeof(T2))
             {
                 action((T2)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7> Switch(Action<T3> action)
         {
-            if (this.value is T3)
+            if (this.origType == typeof(T3))
             {
                 action((T3)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7> Switch(Action<T4> action)
         {
-            if (this.value is T4)
+            if (this.origType == typeof(T4))
             {
                 action((T4)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7> Switch(Action<T5> action)
         {
-            if (this.value is T5)
+            if (this.origType == typeof(T5))
             {
                 action((T5)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7> Switch(Action<T6> action)
         {
-            if (this.value is T6)
+            if (this.origType == typeof(T6))
             {
                 action((T6)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6> Switch(Action<T7> action)
         {
-            if (this.value is T7)
+            if (this.origType == typeof(T7))
             {
                 action((T7)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1638,101 +2503,103 @@ namespace OneOf
     {
         readonly object value;
         bool hasSwitched;
+        Type origType;
 
-        internal OneOfSwitcher(object value, bool hasSwitched)
+        internal OneOfSwitcher(object value, Type origType, bool hasSwitched)
         {
             this.value = value;
             this.hasSwitched = hasSwitched;
+            this.origType = origType;
         }
 
         public OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T0> action)
         {
-            if (this.value is T0)
+            if (this.origType == typeof(T0))
             {
                 action((T0)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T1, T2, T3, T4, T5, T6, T7, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7, T8> Switch(Action<T1> action)
         {
-            if (this.value is T1)
+            if (this.origType == typeof(T1))
             {
                 action((T1)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T2, T3, T4, T5, T6, T7, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7, T8> Switch(Action<T2> action)
         {
-            if (this.value is T2)
+            if (this.origType == typeof(T2))
             {
                 action((T2)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T3, T4, T5, T6, T7, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7, T8> Switch(Action<T3> action)
         {
-            if (this.value is T3)
+            if (this.origType == typeof(T3))
             {
                 action((T3)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T4, T5, T6, T7, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7, T8> Switch(Action<T4> action)
         {
-            if (this.value is T4)
+            if (this.origType == typeof(T4))
             {
                 action((T4)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T5, T6, T7, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7, T8> Switch(Action<T5> action)
         {
-            if (this.value is T5)
+            if (this.origType == typeof(T5))
             {
                 action((T5)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T6, T7, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7, T8> Switch(Action<T6> action)
         {
-            if (this.value is T6)
+            if (this.origType == typeof(T6))
             {
                 action((T6)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T7, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T8> Switch(Action<T7> action)
         {
-            if (this.value is T7)
+            if (this.origType == typeof(T7))
             {
                 action((T7)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T8>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T8>(this.value, this.origType, this.hasSwitched);
         }
 
         public OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7> Switch(Action<T8> action)
         {
-            if (this.value is T8)
+            if (this.origType == typeof(T8))
             {
                 action((T8)value);
                 hasSwitched = true;
             }
-            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(this.value, this.hasSwitched);
+            return new OneOfSwitcher<T0, T1, T2, T3, T4, T5, T6, T7>(this.value, this.origType, this.hasSwitched);
         }
 
         public void Else(Action<object> action)
@@ -1750,15 +2617,17 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
         public TResult Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
             return (TResult)result;
         }
 
@@ -1785,23 +2654,25 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)
@@ -1827,29 +2698,31 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, T2, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, T2, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, T2, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T2, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, T2, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, T2, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, TResult> Match(Func<T2, TResult> createResult)
         {
-            if (result == null && value is T2) result = createResult((T2)value);
-            return new OneOfMatcher<T0, T1, TResult>(this.value, this.result);
+            if (result == null && typeof(T2) == origType) result = createResult((T2)value);
+            return new OneOfMatcher<T0, T1, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)
@@ -1875,35 +2748,37 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, T2, T3, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, T2, T3, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, T2, T3, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T2, T3, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, T2, T3, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, T2, T3, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T3, TResult> Match(Func<T2, TResult> createResult)
         {
-            if (result == null && value is T2) result = createResult((T2)value);
-            return new OneOfMatcher<T0, T1, T3, TResult>(this.value, this.result);
+            if (result == null && typeof(T2) == origType) result = createResult((T2)value);
+            return new OneOfMatcher<T0, T1, T3, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, TResult> Match(Func<T3, TResult> createResult)
         {
-            if (result == null && value is T3) result = createResult((T3)value);
-            return new OneOfMatcher<T0, T1, T2, TResult>(this.value, this.result);
+            if (result == null && typeof(T3) == origType) result = createResult((T3)value);
+            return new OneOfMatcher<T0, T1, T2, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)
@@ -1929,41 +2804,43 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, T2, T3, T4, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, T2, T3, T4, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, T2, T3, T4, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T2, T3, T4, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, T2, T3, T4, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, T2, T3, T4, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T3, T4, TResult> Match(Func<T2, TResult> createResult)
         {
-            if (result == null && value is T2) result = createResult((T2)value);
-            return new OneOfMatcher<T0, T1, T3, T4, TResult>(this.value, this.result);
+            if (result == null && typeof(T2) == origType) result = createResult((T2)value);
+            return new OneOfMatcher<T0, T1, T3, T4, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T4, TResult> Match(Func<T3, TResult> createResult)
         {
-            if (result == null && value is T3) result = createResult((T3)value);
-            return new OneOfMatcher<T0, T1, T2, T4, TResult>(this.value, this.result);
+            if (result == null && typeof(T3) == origType) result = createResult((T3)value);
+            return new OneOfMatcher<T0, T1, T2, T4, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, TResult> Match(Func<T4, TResult> createResult)
         {
-            if (result == null && value is T4) result = createResult((T4)value);
-            return new OneOfMatcher<T0, T1, T2, T3, TResult>(this.value, this.result);
+            if (result == null && typeof(T4) == origType) result = createResult((T4)value);
+            return new OneOfMatcher<T0, T1, T2, T3, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)
@@ -1989,47 +2866,49 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, T2, T3, T4, T5, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, T2, T3, T4, T5, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, T2, T3, T4, T5, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T2, T3, T4, T5, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, T2, T3, T4, T5, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, T2, T3, T4, T5, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T3, T4, T5, TResult> Match(Func<T2, TResult> createResult)
         {
-            if (result == null && value is T2) result = createResult((T2)value);
-            return new OneOfMatcher<T0, T1, T3, T4, T5, TResult>(this.value, this.result);
+            if (result == null && typeof(T2) == origType) result = createResult((T2)value);
+            return new OneOfMatcher<T0, T1, T3, T4, T5, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T4, T5, TResult> Match(Func<T3, TResult> createResult)
         {
-            if (result == null && value is T3) result = createResult((T3)value);
-            return new OneOfMatcher<T0, T1, T2, T4, T5, TResult>(this.value, this.result);
+            if (result == null && typeof(T3) == origType) result = createResult((T3)value);
+            return new OneOfMatcher<T0, T1, T2, T4, T5, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T5, TResult> Match(Func<T4, TResult> createResult)
         {
-            if (result == null && value is T4) result = createResult((T4)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T5, TResult>(this.value, this.result);
+            if (result == null && typeof(T4) == origType) result = createResult((T4)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T5, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, TResult> Match(Func<T5, TResult> createResult)
         {
-            if (result == null && value is T5) result = createResult((T5)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(this.value, this.result);
+            if (result == null && typeof(T5) == origType) result = createResult((T5)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)
@@ -2055,53 +2934,55 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, T2, T3, T4, T5, T6, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, T2, T3, T4, T5, T6, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, T2, T3, T4, T5, T6, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T2, T3, T4, T5, T6, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, T2, T3, T4, T5, T6, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, T2, T3, T4, T5, T6, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T3, T4, T5, T6, TResult> Match(Func<T2, TResult> createResult)
         {
-            if (result == null && value is T2) result = createResult((T2)value);
-            return new OneOfMatcher<T0, T1, T3, T4, T5, T6, TResult>(this.value, this.result);
+            if (result == null && typeof(T2) == origType) result = createResult((T2)value);
+            return new OneOfMatcher<T0, T1, T3, T4, T5, T6, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T4, T5, T6, TResult> Match(Func<T3, TResult> createResult)
         {
-            if (result == null && value is T3) result = createResult((T3)value);
-            return new OneOfMatcher<T0, T1, T2, T4, T5, T6, TResult>(this.value, this.result);
+            if (result == null && typeof(T3) == origType) result = createResult((T3)value);
+            return new OneOfMatcher<T0, T1, T2, T4, T5, T6, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T5, T6, TResult> Match(Func<T4, TResult> createResult)
         {
-            if (result == null && value is T4) result = createResult((T4)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T5, T6, TResult>(this.value, this.result);
+            if (result == null && typeof(T4) == origType) result = createResult((T4)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T5, T6, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T6, TResult> Match(Func<T5, TResult> createResult)
         {
-            if (result == null && value is T5) result = createResult((T5)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T6, TResult>(this.value, this.result);
+            if (result == null && typeof(T5) == origType) result = createResult((T5)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T6, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult> Match(Func<T6, TResult> createResult)
         {
-            if (result == null && value is T6) result = createResult((T6)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(this.value, this.result);
+            if (result == null && typeof(T6) == origType) result = createResult((T6)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)
@@ -2127,59 +3008,61 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, TResult> Match(Func<T2, TResult> createResult)
         {
-            if (result == null && value is T2) result = createResult((T2)value);
-            return new OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T2) == origType) result = createResult((T2)value);
+            return new OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, TResult> Match(Func<T3, TResult> createResult)
         {
-            if (result == null && value is T3) result = createResult((T3)value);
-            return new OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T3) == origType) result = createResult((T3)value);
+            return new OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, TResult> Match(Func<T4, TResult> createResult)
         {
-            if (result == null && value is T4) result = createResult((T4)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T4) == origType) result = createResult((T4)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, TResult> Match(Func<T5, TResult> createResult)
         {
-            if (result == null && value is T5) result = createResult((T5)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T5) == origType) result = createResult((T5)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, TResult> Match(Func<T6, TResult> createResult)
         {
-            if (result == null && value is T6) result = createResult((T6)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T6) == origType) result = createResult((T6)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult> Match(Func<T7, TResult> createResult)
         {
-            if (result == null && value is T7) result = createResult((T7)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(this.value, this.result);
+            if (result == null && typeof(T7) == origType) result = createResult((T7)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)
@@ -2205,65 +3088,67 @@ namespace OneOf
     {
         readonly object value;
         object result;
+        Type origType;
 
-        internal OneOfMatcher(object value, object result)
+        internal OneOfMatcher(object value, Type origType, object result)
         {
             this.value = value;
             this.result = result;
+            this.origType = origType;
         }
 
         public OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, T8, TResult> Match(Func<T0, TResult> createResult)
         {
-            if (result == null && value is T0) result = createResult((T0)value);
-            return new OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T0) == origType) result = createResult((T0)value);
+            return new OneOfMatcher<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, T8, TResult> Match(Func<T1, TResult> createResult)
         {
-            if (result == null && value is T1) result = createResult((T1)value);
-            return new OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T1) == origType) result = createResult((T1)value);
+            return new OneOfMatcher<T0, T2, T3, T4, T5, T6, T7, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, T8, TResult> Match(Func<T2, TResult> createResult)
         {
-            if (result == null && value is T2) result = createResult((T2)value);
-            return new OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T2) == origType) result = createResult((T2)value);
+            return new OneOfMatcher<T0, T1, T3, T4, T5, T6, T7, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, T8, TResult> Match(Func<T3, TResult> createResult)
         {
-            if (result == null && value is T3) result = createResult((T3)value);
-            return new OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T3) == origType) result = createResult((T3)value);
+            return new OneOfMatcher<T0, T1, T2, T4, T5, T6, T7, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, T8, TResult> Match(Func<T4, TResult> createResult)
         {
-            if (result == null && value is T4) result = createResult((T4)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T4) == origType) result = createResult((T4)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T5, T6, T7, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, T8, TResult> Match(Func<T5, TResult> createResult)
         {
-            if (result == null && value is T5) result = createResult((T5)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T5) == origType) result = createResult((T5)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T6, T7, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, T8, TResult> Match(Func<T6, TResult> createResult)
         {
-            if (result == null && value is T6) result = createResult((T6)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T6) == origType) result = createResult((T6)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T7, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T8, TResult> Match(Func<T7, TResult> createResult)
         {
-            if (result == null && value is T7) result = createResult((T7)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T8, TResult>(this.value, this.result);
+            if (result == null && typeof(T7) == origType) result = createResult((T7)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T8, TResult>(this.value, this.origType, this.result);
         }
 
         public OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult> Match(Func<T8, TResult> createResult)
         {
-            if (result == null && value is T8) result = createResult((T8)value);
-            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(this.value, this.result);
+            if (result == null && typeof(T8) == origType) result = createResult((T8)value);
+            return new OneOfMatcher<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(this.value, this.origType, this.result);
         }
 
         public TResult Else(TResult defaultValue)

--- a/OneOf/OneOf.tt
+++ b/OneOf/OneOf.tt
@@ -5,6 +5,7 @@
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="Microsoft.VisualStudio.TextTemplating" #>
 <#@ output extension=".cs" #>
 <# 
 GenerateClasses(); 
@@ -17,6 +18,8 @@ void GenerateClasses()
 	WriteLine("// ===========================================================================");
 	WriteLine("");
 	WriteLine("using System;");
+	WriteLine("using Microsoft.CSharp.RuntimeBinder;");
+	
 	WriteLine("");
 	WriteLine("namespace OneOf");
 	using(new WriteIndent(this))
@@ -48,15 +51,19 @@ void WriteOneOf(bool isStruct, int countOfgenericParams)
 	using(new WriteIndent(this))
 	{
 		WriteLine("readonly object value;");
-
+        WriteLine("readonly Type origType;");
+		
 		// =============== Constructors
 		// must only be called after value has been validated to be Tn
 	    
 		WriteLine("");
-		WriteLine($"{typeName}(object value)");
+        WriteLine($"{typeName}(object value, Type origType)");
+
 		using(new WriteIndent(this))
 		{
-			WriteLine($"this.value = value;");
+			WriteLine("this.value = value;");
+            WriteLine("this.origType = origType;");
+
 		}
 
 		if (!isStruct)
@@ -66,79 +73,115 @@ void WriteOneOf(bool isStruct, int countOfgenericParams)
 			using(new WriteIndent(this))
 			{
 				WriteLine("this.value = this;");
+				WriteLine("this.origType = GetType();");
 			}
 		}
-
-		// =============== Create
-	    
-		WriteLine("");
-		WriteLine($"internal static {typeName}<{genericArg}> Create(object value)");
-		using(new WriteIndent(this))
-		{
-			for(var parmIndex = 0; parmIndex < countOfgenericParams; parmIndex ++)
-			{
-				WriteLine($"if (value is T{parmIndex}) return new {typeName}<{genericArg}>((T{parmIndex})value);");
-			}
-
-			WriteLine($"throw (value == null) ? new ArgumentNullException(nameof(value)) : new ArgumentException(nameof(value));");
-		}
-
-		// =============== IOneOf implementation
+		
+	    // =============== IOneOf implementation
 
 		WriteLine("");
 		WriteLine("object IOneOf.Value => value;");
 
+        // =============== Create/CreateRaw
+        
+        WriteLine("");
+        WriteLine($"internal static {typeName}<{genericArg}> CreateRaw(object value)");
+        using(new WriteIndent(this))
+        {
+			WriteLine("if( value == null) throw new ArgumentNullException(nameof(value));");
+            for(var parmIndex = 0; parmIndex < countOfgenericParams; parmIndex ++)
+            {
+				//cover our fast exact Type matches
+                WriteLine($"if (value.GetType() == typeof(T{parmIndex})) return Create((T{parmIndex})value);");
+            }
+			//prepare to catch any dynamic binding exceptions...
+			WriteLine("try");
+            using(new WriteIndent(this))            
+			{
+				//fall back to best match for non-exact type matches (subclasses, interface implementations, etc.)
+				//by performing double dispatch via dynamic casting. This will attempt to bind to the most specific create method available.
+				// This can be improved via reflection trickery if we decide there is a performance justification for it
+				WriteLine($"return Create((dynamic)value);");
+            }
+            WriteLine("catch(RuntimeBinderException ex)");
+            using (new WriteIndent(this))
+            {
+				//this SHOULDN'T happen thanks to aldready being in the context of a validly casted object, but you never know...
+                WriteLine("throw new ArgumentException(nameof(value), ex);");
+            }
+        }
+
+		WriteLine("");
+		for(var parmIndex = 0; parmIndex < countOfgenericParams; parmIndex ++)
+        {
+			WriteLine($"internal static {typeName}<{genericArg}> Create(T{parmIndex} value)");
+			using(new WriteIndent(this))
+			{         
+				WriteLine($" return new {typeName}<{genericArg}>((T{parmIndex})value, typeof(T{parmIndex}));");
+			}
+		}
+
 		// =============== Is
 
 		WriteLine("");
-		WriteLine($"public bool Is<T>() => (this.value is T);");
+		WriteLine("public bool Is<T>() => typeof(T) == origType;");
+
+		// ================ IsDerivedFrom
+		// necessary due to Is now properly reflecting the original circumstances of this OneOf's creation.
+		WriteLine("");
+		WriteLine("public bool IsDerivedFrom<T>() => value is T;");
 
 		// =============== As
 
 		WriteLine("");
-		WriteLine($"public T As<T>()");
+		WriteLine("public T As<T>()");
 		using(new WriteIndent(this))
 		{
-			WriteLine($"if (this.value is T) return (T)this.value;");
+			WriteLine("if (this.value is T) return (T)this.value;");
 			WriteLine("");
 			WriteLine("throw new InvalidOperationException();");
 		}
 
 		// =============== ToOneOf
-		// Use slower Create method which does type checks at runtime as compiler couldn't check them for us.
+		// now just uses CreateRaw to get best of both worlds for conversion.  Can blow up if user has incompatible types, but the C# Type system is
+		// just not powerful enough for us to save them from that with any reasonable approaches.
+		for (var numberOfGenericsInNew = countOfgenericParams - 1; numberOfGenericsInNew < 9; numberOfGenericsInNew ++)
+	    {
+	            var nargs = Enumerable.Range(0, numberOfGenericsInNew + 1).Select(e => "N" + e).ToArray();
+	            var otherGenericArgs = string.Join(", ", nargs);
+	            WriteLine($"public {typeName}<{otherGenericArgs}> ToOneOf<{otherGenericArgs}>() => {typeName}<{otherGenericArgs}>.CreateRaw(value);");
+	    }
 
-		WriteLine("");
-		for(var newIndex = 2; newIndex < 10; newIndex ++)
-		{
-			var otherGenericArgs = string.Join(", ", Enumerable.Range(0, newIndex).Select(e => "N" + e));
-
-			WriteLine($"public {typeName}<{otherGenericArgs}> ToOneOf<{otherGenericArgs}>() => {typeName}<{otherGenericArgs}>.Create(value);");
-		}
-
-		// =============== implicit conversion to T
-		// Use fast Ctor as compiler can check types for us.
-
+	    // =============== implicit conversion to T
+		// Now uses CreateRaw.  Not much slower than just calling the raw constructor, and ensures we get proper handling for polymorphic situations.
 		WriteLine("");
 		for(var parmIndex = 0; parmIndex < countOfgenericParams; parmIndex ++)
 		{
-			WriteLine($"public static implicit operator {typeName}<{genericArg}>(T{parmIndex} value) => new {typeName}<{genericArg}>(value);"); 
+			WriteLine($"public static implicit operator {typeName}<{genericArg}>(T{parmIndex} value) => CreateRaw(value);"); 
 		}
 
 		// =============== equality operators
-
 		WriteLine("");
-		WriteLine($"public static bool operator ==({typeName}<{genericArg}> v1, {typeName}<{genericArg}> v2) => v1.Equals(v2);"); 
-		WriteLine($"public static bool operator !=({typeName}<{genericArg}> v1, {typeName}<{genericArg}> v2) => !v1.Equals(v2);"); 
+		WriteLine($"public static bool operator ==({typeName}<{genericArg}> v1, IOneOf v2) => v1.Equals(v2);"); 
+		WriteLine($"public static bool operator !=({typeName}<{genericArg}> v1, IOneOf v2) => !v1.Equals(v2);");
+		//also adding equality operators to compare to the various Generic types by value
+	    for (var i = 0; i < countOfgenericParams; i++)
+	    {
+			WriteLine($"public static bool operator ==({typeName}<{genericArg}> v1, T{i} v2) => v1.Equals(v2);"); 
+			WriteLine($"public static bool operator !=({typeName}<{genericArg}> v1, T{i} v2) => !v1.Equals(v2);");
+			WriteLine($"public static bool operator ==(T{i} v1, {typeName}<{genericArg}> v2) => v2.Equals(v1);"); 
+			WriteLine($"public static bool operator !=(T{i} v1, {typeName}<{genericArg}> v2) => !v2.Equals(v1);");
+	    }
+
 
 		// =============== Switch
-
 		WriteLine("");
 		for(var parmIndex = 0; parmIndex < countOfgenericParams; parmIndex ++)
 		{
 			var lesserArityOneOf = Enumerable.Range(0, countOfgenericParams).Where(n => n != parmIndex).ToList();
 			var lesserArityGenericArg = GenerateGenericArgs(lesserArityOneOf);
 
-			WriteLine($"public OneOfSwitcher<{lesserArityGenericArg}> Switch(Action<T{parmIndex}> action) => new OneOfSwitcher<{genericArg}>(value, false).Switch(action);");
+			WriteLine($"public OneOfSwitcher<{lesserArityGenericArg}> Switch(Action<T{parmIndex}> action) => new OneOfSwitcher<{genericArg}>(value, origType, false).Switch(action);");
 		}
 
 		// =============== Match
@@ -149,14 +192,15 @@ void WriteOneOf(bool isStruct, int countOfgenericParams)
 			var lesserArityOneOf = Enumerable.Range(0, countOfgenericParams).Where(n => n != parmIndex).ToList();
 			var lesserArityGenericArg = GenerateGenericArgs(lesserArityOneOf);
 
-			WriteLine($"public OneOfMatcher<{lesserArityGenericArg}, TResult> Match<TResult>(Func<T{parmIndex}, TResult> func)  => new OneOfMatcher<{genericArg}, TResult>(value, null).Match(func);");
+			WriteLine($"public OneOfMatcher<{lesserArityGenericArg}, TResult> Match<TResult>(Func<T{parmIndex}, TResult> func)  => new OneOfMatcher<{genericArg}, TResult>(value, origType, null).Match(func);");
 		}
 
 		// =============== object overrides
 
 		WriteLine("");
-		WriteLine($"public override bool Equals(object obj) => obj is {typeName}<{genericArg}> && Equals(value, (({typeName}<{genericArg}>)obj).value);");
-		WriteLine("public override int GetHashCode() => (value?.GetHashCode() ?? 0);");
+		// Returns true if the object is either an IOneOf, or if the value equals the OneOf, rather than only if it is the same kind of OneOf.
+		WriteLine($"public override bool Equals(object obj) => (obj is IOneOf) && Equals(value, ((IOneOf)obj).Value) || value.Equals(obj);");
+		WriteLine("public override int GetHashCode() => (value?.GetHashCode() ?? origType?.GetHashCode() ?? 0);");
 		WriteLine("public override string ToString() => (value?.ToString() ?? \"\");");
 	}
 }
@@ -171,19 +215,20 @@ void WriteSwitcher(int countOfgenericParams)
 	{
 		WriteLine("readonly object value;");
 		WriteLine("bool hasSwitched;");
+		WriteLine("Type origType;");
 
 		// =============== Constructors
 	    
 		WriteLine("");
-		WriteLine("internal OneOfSwitcher(object value, bool hasSwitched)");
+		WriteLine("internal OneOfSwitcher(object value, Type origType, bool hasSwitched)");
 		using(new WriteIndent(this))
 		{
 			WriteLine($"this.value = value;");
 			WriteLine($"this.hasSwitched = hasSwitched;");
+			WriteLine($"this.origType = origType;");
 		}
 
 		// =============== Switch
-
 		for(var parmIndex = 0; parmIndex < countOfgenericParams; parmIndex++)
 		{
 			var lesserArityOneOf = Enumerable.Range(0, countOfgenericParams).ToList();
@@ -196,13 +241,13 @@ void WriteSwitcher(int countOfgenericParams)
 				WriteLine($"public OneOfSwitcher<{lesserArityGenericArg}> Switch(Action<T{parmIndex}> action)");
 				using(new WriteIndent(this))
 				{
-					WriteLine($"if (this.value is T{parmIndex})");
+					WriteLine($"if (this.origType == typeof(T{parmIndex}))");
 					using(new WriteIndent(this))
 					{
 						WriteLine($"action((T{parmIndex})value);");
 						WriteLine("hasSwitched = true;");
 					}
-					WriteLine($"return new OneOfSwitcher<{lesserArityGenericArg}>(this.value, this.hasSwitched);");
+					WriteLine($"return new OneOfSwitcher<{lesserArityGenericArg}>(this.value, this.origType, this.hasSwitched);");
 				}
 			}
 			else
@@ -211,7 +256,7 @@ void WriteSwitcher(int countOfgenericParams)
 				WriteLine($"public void Switch(Action<T{parmIndex}> action)");
 				using(new WriteIndent(this))
 				{
-					WriteLine($"if (this.value is T{parmIndex}) action((T{parmIndex})value);");
+					WriteLine($"if (this.origType == typeof(T{parmIndex})) action((T{parmIndex})value);");
 				}
 			}
 		}
@@ -246,15 +291,17 @@ void WriteMatcher(int countOfgenericParams)
 	{
 		WriteLine("readonly object value;");
 		WriteLine("object result;");
+		WriteLine("Type origType;");
 
 		// =============== Constructors
 	    
 		WriteLine("");
-		WriteLine("internal OneOfMatcher(object value, object result)");
+		WriteLine("internal OneOfMatcher(object value, Type origType, object result)");
 		using(new WriteIndent(this))
 		{
 			WriteLine($"this.value = value;");
 			WriteLine($"this.result = result;");
+			WriteLine($"this.origType = origType;");
 		}
 
 		// =============== Match
@@ -271,8 +318,8 @@ void WriteMatcher(int countOfgenericParams)
 				WriteLine($"public OneOfMatcher<{lesserArityGenericArg}> Match(Func<T{parmIndex}, TResult> createResult)");
 				using(new WriteIndent(this))
 				{
-					WriteLine($"if (result == null && value is T{parmIndex}) result = createResult((T{parmIndex})value);");
-					WriteLine($"return new OneOfMatcher<{lesserArityGenericArg}>(this.value, this.result);");
+					WriteLine($"if (result == null && typeof(T{parmIndex}) == origType) result = createResult((T{parmIndex})value);");
+					WriteLine($"return new OneOfMatcher<{lesserArityGenericArg}>(this.value, this.origType, this.result);");
 				}
 			}
 			else
@@ -280,7 +327,7 @@ void WriteMatcher(int countOfgenericParams)
 				WriteLine($"public TResult Match(Func<T{parmIndex}, TResult> createResult)");
 				using(new WriteIndent(this))
 				{
-					WriteLine($"if (result == null && value is T{parmIndex}) result = createResult((T{parmIndex})value);");
+					WriteLine($"if (result == null && typeof(T{parmIndex}) == origType) result = createResult((T{parmIndex})value);");
 					WriteLine($"return (TResult)result;");
 				}
             }
@@ -320,9 +367,9 @@ void WriteMatcher(int countOfgenericParams)
 
 class WriteIndent: IDisposable
 {
-	GeneratedTextTransformation textTransformation;
+	TextTransformation textTransformation;
 
-	public WriteIndent(GeneratedTextTransformation textTransformation)
+	public WriteIndent(TextTransformation textTransformation)
 	{
 		this.textTransformation = textTransformation;
 


### PR DESCRIPTION
I'm going to be adding a good bit of commentary to this PR.

Commit Msg:

Properly handling Polymorphism by carrying type info from OneOf creation all the way through the processes of casting, creation, matching, and switching processes.

Also implementing value comparison semantics, allowing all manner of IOneOf's to act transparently for purposes of comparing IOneOf's and their constituent values to one another or non-IOneOf objects.
